### PR TITLE
fix: resolve issues #9, #10, #11

### DIFF
--- a/.gga
+++ b/.gga
@@ -1,0 +1,21 @@
+# Gentleman Guardian Angel Configuration
+# https://github.com/your-org/gga
+
+# AI Provider (required)
+# Using OpenCode Zen API with glm-5.1 model
+PROVIDER="opencode:opencode/glm-5.1"
+
+# File patterns to include in review (comma-separated)
+FILE_PATTERNS="*.ts,*.tsx,*.js,*.jsx,*.astro"
+
+# File patterns to exclude from review (comma-separated)
+EXCLUDE_PATTERNS="*.test.ts,*.spec.ts,*.test.tsx,*.spec.tsx,*.d.ts"
+
+# File containing code review rules
+RULES_FILE="AGENTS.md"
+
+# Strict mode: fail if AI response is ambiguous
+STRICT_MODE="true"
+
+# Timeout in seconds for AI provider response
+TIMEOUT="300"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,48 @@
+# AGENTS.md — Geme Landing
+
+Project-specific rules for AI agents working on this Astro + Tailwind v4 portfolio.
+
+## Stack
+
+- **Framework:** Astro 6.x with Cloudflare adapter (`@astrojs/cloudflare`)
+- **Styling:** Tailwind CSS v4 via `@tailwindcss/vite`
+- **i18n:** Custom namespace-based system (`src/i18n/utils.ts`)
+- **Build:** Static + serverless functions (`src/pages/api/`)
+
+## Coding Standards
+
+### Astro / TypeScript
+- Use `.astro` for pages and components; `.ts` for utilities and API routes.
+- Prefer `const` and explicit types. Avoid `any`.
+- API routes must export `prerender = false` when server-side.
+- Validate all external inputs (forms, query params, JSON bodies).
+
+### i18n
+- Translations live in `src/i18n/{en,es}/` as JSON files.
+- **Do NOT use flat spread merges.** Use the namespace-based `dictionaries` structure in `src/i18n/utils.ts`.
+- Keys follow the pattern `{namespace}.{key}` (e.g., `nav.stack`, `contact.title`).
+- When adding new copy, add it to **both** `en/` and `es/` JSON files.
+
+### Styling (Tailwind v4)
+- Use utility classes. Avoid arbitrary values unless necessary.
+- Theme tokens (`bg-surface`, `text-primary`, etc.) are defined in `src/styles/global.css`.
+- Responsive: mobile-first (`md:` breakpoint for desktop).
+
+### Security
+- Never hardcode secrets (webhook URLs, API keys) in client-side code.
+- Server-side endpoints (`src/pages/api/`) must validate and sanitize input.
+- Reject deprecated/untrusted domains (e.g., `discordapp.com`) before proxying requests.
+
+### Git & Deployment
+- Branch flow: `feature/*` → `dev` → `main` (auto-promotion via CI).
+- Only PRs from `dev` are allowed into `main`.
+- Commits should follow conventional commits (`feat:`, `fix:`, `refactor:`, etc.).
+- Ensure `npm run build` passes before pushing.
+
+## Review Checklist
+
+- [ ] Build passes (`npm run build`)
+- [ ] i18n keys added to both EN and ES
+- [ ] No secrets in client bundles
+- [ ] Server endpoints validate inputs
+- [ ] No flat spread on translation dictionaries

--- a/src/components/nav/Navbar.astro
+++ b/src/components/nav/Navbar.astro
@@ -36,11 +36,11 @@ const t = useTranslations(lang);
         {t('nav.credentials')}
       </a>
       <div class="flex gap-1 font-label text-xs tracking-widest uppercase">
-        <a href="/" class:list={['px-2 py-1 transition-colors', lang === 'en' ? 'text-primary font-bold' : 'text-on-surface-variant/60 hover:text-primary']}>
+        <a href="/" onclick="localStorage.setItem('lang-preference', 'en')" class:list={['px-2 py-1 transition-colors', lang === 'en' ? 'text-primary font-bold' : 'text-on-surface-variant/60 hover:text-primary']}>
           {t('nav.lang.en')}
         </a>
         <span class="text-outline-variant">|</span>
-        <a href="/es" class:list={['px-2 py-1 transition-colors', lang === 'es' ? 'text-primary font-bold' : 'text-on-surface-variant/60 hover:text-primary']}>
+        <a href="/es" onclick="localStorage.setItem('lang-preference', 'es')" class:list={['px-2 py-1 transition-colors', lang === 'es' ? 'text-primary font-bold' : 'text-on-surface-variant/60 hover:text-primary']}>
           {t('nav.lang.es')}
         </a>
       </div>

--- a/src/i18n/utils.ts
+++ b/src/i18n/utils.ts
@@ -25,9 +25,36 @@ import esCta from './es/cta.json' with { type: 'json' };
 import esContact from './es/contact.json' with { type: 'json' };
 import esFooter from './es/footer.json' with { type: 'json' };
 
-const dictionaries: Record<SupportedLang, Record<string, string>> = {
-  en: { ...enMeta, ...enNav, ...enHero, ...enStats, ...enTech, ...enPillars, ...enProjects, ...enCerts, ...enCta, ...enContact, ...enFooter },
-  es: { ...esMeta, ...esNav, ...esHero, ...esStats, ...esTech, ...esPillars, ...esProjects, ...esCerts, ...esCta, ...esContact, ...esFooter },
+type NamespaceDict = Record<string, string>;
+type Dictionary = Record<string, NamespaceDict>;
+
+const dictionaries: Record<SupportedLang, Dictionary> = {
+  en: {
+    meta: enMeta,
+    nav: enNav,
+    hero: enHero,
+    stats: enStats,
+    tech: enTech,
+    pillars: enPillars,
+    projects: enProjects,
+    certs: enCerts,
+    cta: enCta,
+    contact: enContact,
+    footer: enFooter,
+  },
+  es: {
+    meta: esMeta,
+    nav: esNav,
+    hero: esHero,
+    stats: esStats,
+    tech: esTech,
+    pillars: esPillars,
+    projects: esProjects,
+    certs: esCerts,
+    cta: esCta,
+    contact: esContact,
+    footer: esFooter,
+  },
 };
 
 export function getLangFromUrl(url: URL): SupportedLang {
@@ -37,7 +64,17 @@ export function getLangFromUrl(url: URL): SupportedLang {
 }
 
 export function useTranslations(lang: SupportedLang) {
-  return function t(key: keyof typeof dictionaries.en): string {
-    return dictionaries[lang][key] ?? dictionaries.en[key] ?? key;
+  return function t(key: string): string {
+    const dict = dictionaries[lang];
+    const fallbackDict = dictionaries.en;
+
+    // Search in every namespace for an exact key match
+    for (const ns of Object.values(dict)) {
+      if (key in ns) return ns[key];
+    }
+    for (const ns of Object.values(fallbackDict)) {
+      if (key in ns) return ns[key];
+    }
+    return key;
   };
 }

--- a/src/i18n/utils.ts
+++ b/src/i18n/utils.ts
@@ -57,6 +57,29 @@ const dictionaries: Record<SupportedLang, Dictionary> = {
   },
 };
 
+// Build an inverted index for O(1) lookup and detect collisions at startup
+type TranslationKey = keyof typeof enMeta
+  | keyof typeof enNav
+  | keyof typeof enHero
+  | keyof typeof enStats
+  | keyof typeof enTech
+  | keyof typeof enPillars
+  | keyof typeof enProjects
+  | keyof typeof enCerts
+  | keyof typeof enCta
+  | keyof typeof enContact
+  | keyof typeof enFooter;
+
+const keyToNamespace: Map<string, string> = new Map();
+for (const [ns, dict] of Object.entries(dictionaries.en)) {
+  for (const key of Object.keys(dict)) {
+    if (keyToNamespace.has(key)) {
+      console.warn(`i18n collision detected: "${key}" exists in both "${keyToNamespace.get(key)}" and "${ns}"`);
+    }
+    keyToNamespace.set(key, ns);
+  }
+}
+
 export function getLangFromUrl(url: URL): SupportedLang {
   const [, segment] = url.pathname.split('/');
   if (segment === 'es' || segment?.startsWith('es')) return 'es';
@@ -64,17 +87,9 @@ export function getLangFromUrl(url: URL): SupportedLang {
 }
 
 export function useTranslations(lang: SupportedLang) {
-  return function t(key: string): string {
-    const dict = dictionaries[lang];
-    const fallbackDict = dictionaries.en;
-
-    // Search in every namespace for an exact key match
-    for (const ns of Object.values(dict)) {
-      if (key in ns) return ns[key];
-    }
-    for (const ns of Object.values(fallbackDict)) {
-      if (key in ns) return ns[key];
-    }
-    return key;
+  return function t(key: TranslationKey): string {
+    const ns = keyToNamespace.get(key);
+    if (!ns) return key;
+    return dictionaries[lang][ns]?.[key] ?? dictionaries.en[ns]?.[key] ?? key;
   };
 }

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -65,7 +65,9 @@ const ogImage = new URL('/gemewolf-tight.png', Astro.site ?? Astro.url.origin).h
     <script is:inline>
       (function () {
         const saved = localStorage.getItem('lang-preference');
-        if (!saved && navigator.language.startsWith('es') && location.pathname === '/') {
+        const isSpanishBrowser = navigator.language.startsWith('es');
+        if (location.pathname !== '/') return;
+        if (saved === 'es' || (!saved && isSpanishBrowser)) {
           location.href = '/es/';
         }
       })();

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -63,9 +63,12 @@ const ogImage = new URL('/gemewolf-tight.png', Astro.site ?? Astro.url.origin).h
 
     <!-- Browser language detection — redirect Spanish users to /es/ -->
     <script is:inline>
-      if (navigator.language.startsWith('es') && location.pathname === '/') {
-        location.href = '/es/';
-      }
+      (function () {
+        const saved = localStorage.getItem('lang-preference');
+        if (!saved && navigator.language.startsWith('es') && location.pathname === '/') {
+          location.href = '/es/';
+        }
+      })();
     </script>
   </head>
   <body class="antialiased min-h-screen">

--- a/src/pages/api/contact.ts
+++ b/src/pages/api/contact.ts
@@ -13,16 +13,22 @@ export const POST: APIRoute = async ({ request, locals }) => {
     });
   }
 
-  if (webhookUrl.includes('discordapp.com')) {
-    return new Response(
-      JSON.stringify({
-        error: 'Discord webhook URL uses deprecated domain. Please update DISCORD_WEBHOOK_URL to use discord.com',
-      }),
-      {
-        status: 400,
-        headers: { 'Content-Type': 'application/json' },
-      }
-    );
+  try {
+    const url = new URL(webhookUrl);
+    if (url.hostname === 'discordapp.com') {
+      return new Response(
+        JSON.stringify({ error: 'Server misconfiguration' }),
+        {
+          status: 500,
+          headers: { 'Content-Type': 'application/json' },
+        }
+      );
+    }
+  } catch {
+    return new Response(JSON.stringify({ error: 'Invalid webhook URL' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    });
   }
 
   let body: Record<string, unknown>;

--- a/src/pages/api/contact.ts
+++ b/src/pages/api/contact.ts
@@ -13,6 +13,18 @@ export const POST: APIRoute = async ({ request, locals }) => {
     });
   }
 
+  if (webhookUrl.includes('discordapp.com')) {
+    return new Response(
+      JSON.stringify({
+        error: 'Discord webhook URL uses deprecated domain. Please update DISCORD_WEBHOOK_URL to use discord.com',
+      }),
+      {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      }
+    );
+  }
+
   let body: Record<string, unknown>;
   try {
     body = await request.json();


### PR DESCRIPTION
## Summary

This PR resolves three open issues:

- **#10** — Replace flat i18n spread with namespaced dictionaries to prevent silent key collisions
- **#11** — Respect explicit language preference via localStorage in auto-redirect and navbar  
- **#9** — Reject deprecated discordapp.com webhook URLs in contact API endpoint

## Changes

| File | Change |
|------|--------|
|  | Namespaced dictionaries instead of flat spread merge |
|  | Check  before auto-redirect |
|  | Save language preference to localStorage on manual switch |
|  | Reject webhook URLs using deprecated  domain |
|  | GGA config for opencode/glm-5.1 |
|  | Project coding standards for AI review |

## Verification

- [x] 
> geme-landing@1.0.0 build
> astro build

00:19:21 [@astrojs/cloudflare] Enabling image processing with Cloudflare Images for production with the "IMAGES" Images binding.
00:19:21 [@astrojs/cloudflare] Enabling sessions with Cloudflare KV with the "SESSION" KV binding.
00:19:22 [types] Generated 1.24s
00:19:22 [build] output: "static"
00:19:22 [build] mode: "server"
00:19:22 [build] directory: /home/geme/github/geme-landing/dist/
00:19:22 [build] adapter: @astrojs/cloudflare
00:19:22 [build] Collecting build info...
00:19:22 [build] ✓ Completed in 1.26s.
00:19:22 [build] Building server entrypoints...
00:19:23 [vite] ✓ built in 1.10s
00:19:24 [vite] ✓ built in 610ms
00:19:24 [vite] ✓ built in 54ms

 prerendering static routes 
00:19:24   ├─ /es/index.html (+236ms) 
00:19:25   ├─ /index.html (+232ms) 
00:19:25 ✓ Completed in 734ms.

00:19:25 [build] Rearranging server assets...
00:19:25 [build] ✓ Completed in 2.56s.
00:19:25 [build] Server built in 3.82s
00:19:25 [build] Complete! passes
- [x] GGA code review passed with opencode:glm-5.1

Closes #9
Closes #10
Closes #11