### PR TITLE
fix: change Astro assets dir from _astro to assets

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -6,7 +6,7 @@ import cloudflare from '@astrojs/cloudflare';
 // https://astro.build/config
 export default defineConfig({
   adapter: cloudflare(),
-  build: { format: 'directory' },
+  build: { format: 'directory', assets: 'assets' },
   image: {
     remotePatterns: [{ hostname: 'lh3.googleusercontent.com' }],
   },


### PR DESCRIPTION
Cloudflare Pages ignora archivos/directorios que empiezan con `_` (underscore). El build de Astro pone los assets hasheados en `_astro/`, lo que causa 404 en producción.

Este cambio mueve el directorio de assets a `assets/`, que Cloudflare Pages sí sirve correctamente.

Fixes la página sin estilos en producción.